### PR TITLE
[WFLY-10725]: Propagate locator config for recovery.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
    </licenses>
 
    <properties>
-      <artemis.version>2.16.0</artemis.version>
+      <artemis.version>2.17.0</artemis.version>
    </properties>
 
    <parent>

--- a/src/main/java/org/jboss/activemq/artemis/wildfly/integration/recovery/WildFlyActiveMQRecoveryRegistry.java
+++ b/src/main/java/org/jboss/activemq/artemis/wildfly/integration/recovery/WildFlyActiveMQRecoveryRegistry.java
@@ -197,7 +197,8 @@ public class WildFlyActiveMQRecoveryRegistry implements XAResourceRecovery
                                                         username,
                                                         password,
                                                         properties,
-                                                        listeningConfig.getClientProtocolManager());
+                                                        listeningConfig.getClientProtocolManager(),
+                                                        listeningConfig.getLocatorConfig());
 
          ActiveMQXAResourceWrapper xaResource = new ActiveMQXAResourceWrapper(config);
 


### PR DESCRIPTION
 * Updating to Artemis 2.17.0 to have the proper API available
 * Passing the locator config to the recovery configuration for Artemis

Jira: https://issues.redhat.com/browse/WFLY-10725

Supersedes https://github.com/rh-messaging/artemis-wildfly-integration/pull/20