### PR TITLE
[WFLY-17362]: Transaction remained in prepared state after failover.

### DIFF
--- a/artemis-wildfly-integration/src/main/java/org/jboss/activemq/artemis/wildfly/integration/recovery/WildFlyRecoveryDiscovery.java
+++ b/artemis-wildfly-integration/src/main/java/org/jboss/activemq/artemis/wildfly/integration/recovery/WildFlyRecoveryDiscovery.java
@@ -137,7 +137,7 @@ public class WildFlyRecoveryDiscovery implements SessionFailureListener {
                 if (topologyMember.getLive() != null) {
                     TransportConfiguration[] connector;
                     if (topologyMember.getBackup() != null) {
-                        connector = new TransportConfiguration[]{topologyMember.getLive(), topologyMember.getLive()};
+                        connector = new TransportConfiguration[]{topologyMember.getLive(), topologyMember.getBackup()};
                     } else {
                         connector = new TransportConfiguration[]{topologyMember.getLive()};
                     }


### PR DESCRIPTION
* Instead of falling back to backup the recovery would stay on the stopped live server.

Jira: https://issues.redhat.com/browse/WFLY-17362

Signed-off-by: Emmanuel Hugonnet <ehugonne@redhat.com>