### PR TITLE
Updating dependencies to WildFly 35

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>46</version>
+        <version>47</version>
     </parent>
 
     <groupId>org.jboss.activemq.artemis.integration</groupId>
@@ -21,7 +21,7 @@
     </licenses>
 
     <properties>
-        <artemis.version>2.37.0</artemis.version>
+        <artemis.version>2.38.0</artemis.version>
         <jboss-transaction-spi.version>7.6.1.Final</jboss-transaction-spi.version>
     </properties>
 
@@ -33,7 +33,7 @@
             <dependency>
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging-processor</artifactId>
-                <version>2.2.1.Final</version>
+                <version>3.0.3.Final</version>
             </dependency>
 
             <!--
@@ -42,7 +42,7 @@
             <dependency>
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging</artifactId>
-                <version>3.5.0.Final</version>
+                <version>3.6.1.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.logmanager</groupId>
@@ -53,7 +53,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.36</version>
+                <version>2.0.16</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>

--- a/src/main/java/org/jboss/activemq/artemis/wildfly/integration/recovery/WildFlyActiveMQLogger.java
+++ b/src/main/java/org/jboss/activemq/artemis/wildfly/integration/recovery/WildFlyActiveMQLogger.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.activemq.artemis.wildfly.integration.recovery;
 
+import java.lang.invoke.MethodHandles;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.service.extensions.xa.recovery.XARecoveryConfig;
 import org.jboss.logging.BasicLogger;
@@ -49,7 +50,7 @@ public interface WildFlyActiveMQLogger extends BasicLogger {
     /**
      * The default logger.
      */
-    WildFlyActiveMQLogger LOGGER = Logger.getMessageLogger(WildFlyActiveMQLogger.class, WildFlyActiveMQLogger.class.getPackage().getName());
+    WildFlyActiveMQLogger LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), WildFlyActiveMQLogger.class, "org.jboss.activemq.artemis.wildfly.integration.recovery");
 
     @LogMessage(level = Logger.Level.INFO)
     @Message(id = 121003, value = "JMS Server Manager Running cached command for {0}", format = Message.Format.MESSAGE_FORMAT)


### PR DESCRIPTION
Updating Artemis to 2.38.0
Updating JBoss Logging to WildFly 35:
  - jboss-logging 3.5.0.Final -> 3.6.1.Final
  - jboss-logging-processor 2.2.1.Final -> 3.0.3.Final